### PR TITLE
Buffer the updates to subgraphs

### DIFF
--- a/include/mc_gpu_sketch_alg.h
+++ b/include/mc_gpu_sketch_alg.h
@@ -65,7 +65,7 @@ class SketchSubgraph {
 
     subgraph_gutters.resize(num_nodes);
     for (node_id_t i = 0; i < num_nodes; i++) {
-      subgraph_gutters[i].resize(batch_size);
+      subgraph_gutters[i].reserve(batch_size);
     }
     gutter_locks = new std::mutex[num_nodes];
   }
@@ -86,6 +86,7 @@ class SketchSubgraph {
     for (node_id_t v = 0; v < num_nodes; v++) {
       if (subgraph_gutters[v].size() > 0) {
         apply_update_batch(0, v, subgraph_gutters[v]);
+        subgraph_gutters[v].clear();
       }
     }
 

--- a/include/mc_gpu_sketch_alg.h
+++ b/include/mc_gpu_sketch_alg.h
@@ -42,7 +42,9 @@ class SketchSubgraph {
 
   void initialize(MCGPUSketchAlg *sketching_alg, int graph_id, node_id_t num_nodes,
                   int num_host_threads, int num_device_threads, int num_batch_per_buffer,
-                  SketchParams _sketchParams) : num_nodes(num_nodes) {
+                  size_t batch_size, SketchParams _sketchParams) {
+    num_nodes = num_nodes;
+    batch_size = batch_size;
     num_updates = 0;
     num_streams = num_host_threads;
     cuda_streams = new CudaStream<MCGPUSketchAlg>*[num_host_threads];
@@ -60,8 +62,6 @@ class SketchSubgraph {
           new CudaStream<MCGPUSketchAlg>(sketching_alg, graph_id, num_nodes, num_device_threads,
                                          num_batch_per_buffer, sketchParams);
     }
-
-    batch_size = sketching_alg->get_desired_updates_per_batch();
 
     subgraph_gutters.resize(num_nodes);
     for (node_id_t i = 0; i < num_nodes; i++) {
@@ -198,8 +198,8 @@ public:
 
     // Initialize Sketch Graphs
     for (int i = 0; i < cur_subgraphs; i++) {
-      subgraphs[i].initialize(this, i, num_nodes, num_host_threads, num_device_threads, num_batch_per_buffer,
-             default_skt_params);
+      subgraphs[i].initialize(this, i, num_nodes, num_host_threads, num_device_threads,
+                              num_batch_per_buffer, batch_size, default_skt_params);
       create_sketch_graph(i, subgraphs[i].get_skt_params());
     }
 

--- a/include/mc_gpu_sketch_alg.h
+++ b/include/mc_gpu_sketch_alg.h
@@ -77,9 +77,10 @@ class SketchSubgraph {
   }
 
   // Insert an edge to the subgraph
-  // TODO: Make this thread-safe. Basically reusing the standalone gutters design?
-  void insert(int thr_id, node_id_t src, node_id_t dst) {
+  void batch_insert(int thr_id, node_id_t src, node_id_t dst) {
     auto &gutter = subgraph_gutters[src];
+    std::lock_guard<std::mutex> lk(gutter_locks[src]);
+
     gutter.data[gutter.elms++] = dst;
 
     if (gutter.elms >= batch_size) {

--- a/include/mc_gpu_sketch_alg.h
+++ b/include/mc_gpu_sketch_alg.h
@@ -92,7 +92,7 @@ class SketchSubgraph {
     // flush subgraph gutters
     for (node_id_t v = 0; v < num_nodes; v++) {
       if (subgraph_gutters[v].elms > 0) {
-        subgraph_gutters[v].resize(subgraph_gutters[v].elms);
+        subgraph_gutters[v].data.resize(subgraph_gutters[v].elms);
         apply_update_batch(0, v, subgraph_gutters[v].data);
         subgraph_gutters[v].elms = 0;
         subgraph_gutters[v].data.resize(batch_size);

--- a/src/mc_gpu_sketch_alg.cpp
+++ b/src/mc_gpu_sketch_alg.cpp
@@ -34,13 +34,21 @@ void MCGPUSketchAlg::complete_update_batch(int thr_id, const TaggedUpdateBatch &
   auto &dsts_data = updates.dsts_data;
   node_id_t max_subgraph = 0;
 
+  std::vector<std::array<node_id_t, 16>> subgraph_buffers;
+  subgraphs.resize(max_subgraph);
+  std::array<size_t, 16> buffer_sizes;
+
   for (size_t i = 0; i < dsts_data.size(); i++) {
     auto &dst_data = dsts_data[i];
     node_id_t update_subgraphs = std::min(dst_data.subgraph, first_es_subgraph - 1);
     max_subgraph = std::max(update_subgraphs, max_subgraph);
 
     for (size_t graph_id = min_subgraph; graph_id <= update_subgraphs; graph_id++) {
-      subgraphs[graph_id].insert(thr_id, src_vertex, dst_data.dst);
+      subgraph_buffers[src_vertex][buffer_sizes[src_vertex]++] = dsts_data.dst;
+      if (buffer_sizes[src_vertex]] >= 16) {
+        subgraphs[graph_id].batch_insert(thr_id, src_vertex, subgraph_buffers[src_vertex]);
+        buffer_sizes[src_vertex] = 0;
+      }
     }
   }
 }

--- a/src/mc_gpu_sketch_alg.cpp
+++ b/src/mc_gpu_sketch_alg.cpp
@@ -20,8 +20,9 @@ void MCGPUSketchAlg::complete_update_batch(int thr_id, const TaggedUpdateBatch &
 
     // double check to ensure no one else performed the allocation 
     if (first_es_subgraph > cur_subgraphs) {
-      subgraphs[cur_subgraphs].initialize(this, cur_subgraphs, num_nodes, num_host_threads, num_device_threads, num_batch_per_buffer,
-             default_skt_params);
+      subgraphs[cur_subgraphs].initialize(this, cur_subgraphs, num_nodes, num_host_threads,
+                                          num_device_threads, num_batch_per_buffer, batch_size,
+                                          default_skt_params);
       create_sketch_graph(cur_subgraphs, subgraphs[cur_subgraphs].get_skt_params());
       cur_subgraphs++; // do this last so that threads only touch params/sketches when initialized
     }

--- a/src/mc_gpu_sketch_alg.cpp
+++ b/src/mc_gpu_sketch_alg.cpp
@@ -35,13 +35,13 @@ void MCGPUSketchAlg::complete_update_batch(int thr_id, const TaggedUpdateBatch &
   node_id_t max_subgraph = 0;
 
   for (size_t i = 0; i < dsts_data.size(); i++) {
-     auto &dst_data = dsts_data[i];
-     node_id_t update_subgraphs = std::min(dst_data.subgraph, first_es_subgraph - 1);
-     max_subgraph = std::max(update_subgraphs, max_subgraph);
+    auto &dst_data = dsts_data[i];
+    node_id_t update_subgraphs = std::min(dst_data.subgraph, first_es_subgraph - 1);
+    max_subgraph = std::max(update_subgraphs, max_subgraph);
 
-     for (size_t graph_id = min_subgraph; graph_id <= update_subgraphs; graph_id++) {
-        subgraphs[graph_id].insert(thr_id, src_vertex, dst_data.dst);
-     }
+    for (size_t graph_id = min_subgraph; graph_id <= update_subgraphs; graph_id++) {
+      subgraphs[graph_id].insert(thr_id, src_vertex, dst_data.dst);
+    }
   }
 }
 


### PR DESCRIPTION
For "later" subgraphs we only have a small number of updates per batch. So we want to buffer these updates and only apply them when they are ready. This increases memory consumption but seems to help performance.

TODOs:
- [x] Test on Mingun's cluster that this helps performance. (Seems to help on my end)
- [ ] Can we think of a better way to achieve a similar effect but without the memory blowup? (e.g. what if we just made the batches bigger?) 