### PR TITLE
Incorporate faster pipeline hypertree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(GraphZeppelin LANGUAGES CXX CUDA)
 
+include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
+
 include (FetchContent)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -56,7 +58,7 @@ FetchContent_Declare(
   GutterTree
 
   GIT_REPOSITORY  https://github.com/GraphStreamingProject/GutterTree.git
-  GIT_TAG         main
+  GIT_TAG         better_pht
 )
 
 # Get StreamingUtilities

--- a/include/graph_sketch_driver.h
+++ b/include/graph_sketch_driver.h
@@ -152,28 +152,29 @@ class GraphSketchDriver {
 #endif
 
       while (true) {
+        bool got_breakpoint = false;
         size_t updates = stream->get_update_buffer(update_array, update_array_size);
+
+        if (update_array[updates - 1].type == BREAKPOINT) {
+          --updates;
+          got_breakpoint = true;
+        }
+        gts->process_stream_upd_batch(update_array, updates, thr_id);
+
         for (size_t i = 0; i < updates; i++) {
-          GraphUpdate upd;
-          upd.edge = update_array[i].edge;
-          upd.type = static_cast<UpdateType>(update_array[i].type);
-          if (upd.type == BREAKPOINT) {
-            // reached the breakpoint. Update verifier if applicable and return
+          GraphUpdate upd = {update_array[i].edge, (UpdateType) update_array[i].type};
+          sketching_alg->pre_insert(upd, thr_id);
 #ifdef VERIFY_SAMPLES_F
-            std::lock_guard<std::mutex> lk(verifier_mtx);
-            verifier->combine(local_verifier);
+          local_verifier.edge_update(upd.edge);
 #endif
-            return;
-          }
-          else {
-            sketching_alg->pre_insert(upd, thr_id);
-            Edge edge = upd.edge;
-            gts->insert({edge.src, edge.dst}, thr_id);
-            gts->insert({edge.dst, edge.src}, thr_id);
+        }
+
+        if (got_breakpoint) {
 #ifdef VERIFY_SAMPLES_F
-            local_verifier.edge_update(edge);
+          std::lock_guard<std::mutex> lk(verifier_mtx);
+          verifier->combine(local_verifier);
 #endif
-          }
+          return;
         }
       }
     };

--- a/test/edge_store_test.cpp
+++ b/test/edge_store_test.cpp
@@ -72,7 +72,7 @@ TEST(EdgeStoreTest, contract) {
       }
       ASSERT_TRUE(edges_added.insert({src, dst}).second);
     }
-    auto more_upds = edge_store.insert_adj_edges(i, edge_store.get_first_store_subgraph(), dsts);
+    auto more_upds = edge_store.insert_adj_edges(i, edge_store.get_first_store_subgraph(), dsts.data(), dsts.size());
     node_id_t src = more_upds.src;
     for (auto dst_data : more_upds.dsts_data) {
       ++num_returned[edge_store.get_first_store_subgraph() - 1];


### PR DESCRIPTION
I optimized the PHT to make it faster. This improves performance of the code significantly.

The main branch (on the computer I have access to) gets the following performance on kron_17. This new code improves performance by about 12%.
|Version | Throughput (million/sec) |
|-|-|
main           |  719 |
better_pht | 808 |