### PR TITLE
Improve edge store design

### DIFF
--- a/include/edge_store.h
+++ b/include/edge_store.h
@@ -41,6 +41,9 @@ class EdgeStore {
 
 #ifdef VERIFY_SAMPLES_F
   void verify_contract_complete();
+  std::atomic<size_t> num_inserted;
+  std::atomic<size_t> num_duplicate;
+  std::atomic<size_t> num_returned;
 #endif
  public:
   // Constructor

--- a/include/edge_store.h
+++ b/include/edge_store.h
@@ -1,33 +1,38 @@
 #pragma once
 
 #include <atomic>
+#include <iostream>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
-#include <iostream>
 
 #include "types.h"
 
 class EdgeStore {
  private:
+  static constexpr size_t store_edge_bytes = sizeof(SubgraphTaggedUpdate);  // Bytes of one edge
+  static constexpr double contract_factor = 2; // switch to sketch when within this factor of max
+
   size_t seed;
   node_id_t num_vertices;
   size_t num_subgraphs;
-  volatile size_t cur_subgraph = 0; // subgraph depth at which edges enter the edge store
-  volatile size_t true_min_subgraph = 0; // the minimum subgraph of elements in the store
+  volatile size_t cur_subgraph = 0;       // subgraph depth at which edges enter the edge store
+  volatile size_t true_min_subgraph = 0;  // the minimum subgraph of elements in the store
 
   std::atomic<edge_id_t> num_edges;
   std::atomic<node_id_t> needs_contraction;
 
-  std::vector<std::unordered_map<node_id_t, node_id_t>> adjlist;
+  std::vector<std::vector<SubgraphTaggedUpdate>> adjlist;
 
   // This is a vector of booleans BUT we don't want to use vector<bool> because its not
   // multithread friendly
   std::vector<char> vertex_contracted;
 
-  size_t sketch_bytes;        // Bytes of sketch graph
-  static constexpr size_t store_edge_bytes = sizeof(SubgraphTaggedUpdate);  // Bytes of one edge
+  size_t max_edges;                  // Bytes of sketch graph
+  size_t default_buffer_allocation;  // size we allocate each buffer in adjlist to
 
+  // locks that protect the adjacency list
+  // we have a single lock for each vertex and a lock for handling contraction logic
   std::mutex* adj_mutex;
   std::mutex contract_lock;
 
@@ -38,7 +43,6 @@ class EdgeStore {
   void verify_contract_complete();
 #endif
  public:
-
   // Constructor
   EdgeStore(size_t seed, node_id_t num_vertices, size_t sketch_bytes, size_t num_subgraphs,
             size_t start_subgraph = 0);
@@ -52,22 +56,16 @@ class EdgeStore {
 
   // this function is called when there are some sketch subgraphs.
   TaggedUpdateBatch insert_adj_edges(node_id_t src, node_id_t caller_first_es_subgraph,
-                                     SubgraphTaggedUpdate* dst_data, int dst_data_size);
+                                     SubgraphTaggedUpdate* dst_data, size_t dst_data_size);
 
-  // contract vertex data by removing all updates bound for lower subgraphs than the store 
+  // contract vertex data by removing all updates bound for lower subgraphs than the store
   // is responsible for
   TaggedUpdateBatch vertex_advance_subgraph(node_id_t cur_first_es_subgraph);
 
   // Get methods
-  size_t get_num_edges() {
-    return num_edges;
-  }
-  size_t get_footprint() {
-    return num_edges * store_edge_bytes;
-  }
-  size_t get_first_store_subgraph() {
-    return cur_subgraph;
-  }
+  size_t get_num_edges() { return num_edges; }
+  size_t get_footprint() { return num_edges * store_edge_bytes; }
+  size_t get_first_store_subgraph() { return cur_subgraph; }
   std::vector<Edge> get_edges();
   bool contract_in_progress() { return true_min_subgraph < cur_subgraph; }
 };

--- a/include/types.h
+++ b/include/types.h
@@ -24,6 +24,13 @@ struct SubgraphTaggedUpdate {
 
     return subgraph < oth.subgraph;
   }
+
+  bool operator>(const SubgraphTaggedUpdate& oth) const {
+    if (subgraph == oth.subgraph)
+      return dst > oth.dst;
+
+    return subgraph > oth.subgraph;
+  }
 };
 
 struct TaggedUpdateBatch {

--- a/src/edge_store.cpp
+++ b/src/edge_store.cpp
@@ -11,12 +11,18 @@ EdgeStore::EdgeStore(size_t seed, node_id_t num_vertices, size_t sketch_bytes, s
       num_subgraphs(num_subgraphs),
       adjlist(num_vertices),
       vertex_contracted(num_vertices, true),
-      sketch_bytes(sketch_bytes) {
+      max_edges(sketch_bytes / store_edge_bytes),
+      default_buffer_allocation(max_edges / num_vertices) {
   num_edges = 0;
   adj_mutex = new std::mutex[num_vertices];
 
   cur_subgraph = start_subgraph;
   true_min_subgraph = start_subgraph;
+
+  // reserve some space for each
+  for (node_id_t i = 0; i < num_vertices; i++) {
+    adjlist[i].reserve(default_buffer_allocation);
+  }
 }
 
 EdgeStore::~EdgeStore() {
@@ -26,80 +32,70 @@ EdgeStore::~EdgeStore() {
 // caller_first_es_subgraph is implied to be 0 when calling this function
 TaggedUpdateBatch EdgeStore::insert_adj_edges(node_id_t src,
                                                    const std::vector<node_id_t> &dst_vertices) {
-  int edges_delta = 0;
-  std::vector<SubgraphTaggedUpdate> ret;
-  node_id_t cur_first_es_subgraph;
-  {
-    std::lock_guard<std::mutex> lk(adj_mutex[src]);
-    cur_first_es_subgraph = cur_subgraph;
-    if (true_min_subgraph < cur_first_es_subgraph && !vertex_contracted[src]) {
-      ret = vertex_contract(src);
-    }
-
-    for (auto dst : dst_vertices) {
-      auto idx = concat_pairing_fn(src, dst);
-      SubgraphTaggedUpdate data = {Bucket_Boruvka::get_index_depth(idx, seed, num_subgraphs), dst};
-
-      if (cur_first_es_subgraph > 0) {
-        ret.push_back(data); // add everything in dst_vertices to ret
-        if (data.subgraph < cur_first_es_subgraph) continue; // skip stuff that shouldn't be added
-      }
-
-      if (!adjlist[src].insert({dst, data.subgraph}).second) {
-        // Current edge already exist, so delete
-        if (adjlist[src].erase(dst) == 0) {
-          std::cerr << "ERROR: We found a duplicate but couldn't remove???" << std::endl;
-          exit(EXIT_FAILURE);
-        }
-        edges_delta--;
-      } else {
-        edges_delta++;
-      }
-    }
+  
+  std::vector<SubgraphTaggedUpdate> tagged_updates;
+  tagged_updates.resize(dst_vertices.size());
+  for (node_id_t i = 0; i < dst_vertices.size(); i++) {
+    node_id_t dst = dst_vertices[i];
+    auto idx = concat_pairing_fn(src, dst);
+    tagged_updates[i] = {Bucket_Boruvka::get_index_depth(idx, seed, num_subgraphs), dst};
   }
-  num_edges += edges_delta;
-
-  if (ret.size() == 0 && true_min_subgraph < cur_first_es_subgraph) {
-    return vertex_advance_subgraph(cur_first_es_subgraph);
-  } else {
-    check_if_too_big();
-    return {src, cur_first_es_subgraph - 1, cur_first_es_subgraph, ret};
-  }
+  return insert_adj_edges(src, 0, tagged_updates.data(), tagged_updates.size());
 }
 
+// TODO: Switch this over to take in a vector. Arrays are so Ohio
 TaggedUpdateBatch EdgeStore::insert_adj_edges(node_id_t src, node_id_t caller_first_es_subgraph,
-                                              SubgraphTaggedUpdate *dst_data, int dst_data_size) {
+                                              SubgraphTaggedUpdate *dst_data,
+                                              size_t dst_data_size) {
   int edges_delta = 0;
   std::vector<SubgraphTaggedUpdate> ret;
   node_id_t cur_first_es_subgraph;
+  
+
+  // Sort the input data
+  std::sort(dst_data, dst_data + dst_data_size);
+
+  // merge the input data into the vertex buffer
   {
     std::lock_guard<std::mutex> lk(adj_mutex[src]);
     cur_first_es_subgraph = cur_subgraph;
+
+    auto &data_buffer = adjlist[src];
+    size_t orig_size = data_buffer.size();
+
+    size_t out_ptr = 0;
+    size_t buffer_ptr = 0;
+    size_t update_ptr = 0;
+
+    while (buffer_ptr < data_buffer.size()) {
+      if (data_buffer[buffer_ptr] > dst_data[update_ptr]) {
+        SubgraphTaggedUpdate temp = data_buffer[buffer_ptr];
+        data_buffer[out_ptr] = dst_data[update_ptr];
+        dst_data[update_ptr] = temp;
+        ++buffer_ptr;
+      }
+      else if (data_buffer[buffer_ptr] < dst_data[update_ptr]) {
+        ++buffer_ptr;
+      } else { // they are equal! Delete them both
+        ++buffer_ptr;
+        ++update_ptr;
+
+        // edge case introduced here. update_ptr can exceed bounds of dst_data
+        if (update_ptr >= dst_data_size) break;
+      }
+    }
+
+    data_buffer.resize(out_ptr + (dst_data_size - update_ptr));
+    while (update_ptr <= dst_data_size) {
+      data_buffer[out_ptr++] = dst_data[update_ptr++];
+    }
+
+    num_edges += out_ptr - orig_size;
+
     if (true_min_subgraph < cur_first_es_subgraph && !vertex_contracted[src]) {
       ret = vertex_contract(src);
     }
-
-    for (int id = 0; id < dst_data_size; id++) {
-      SubgraphTaggedUpdate data = dst_data[id];
-      if (cur_first_es_subgraph > caller_first_es_subgraph) {
-        ret.push_back(data); // add everything in dst_vertices to ret
-
-        if (data.subgraph < cur_first_es_subgraph) continue; // skip stuff that shouldn't be added
-      }
-
-      if (!adjlist[src].insert({data.dst, data.subgraph}).second) {
-        // Current edge already exist, so delete
-        if (adjlist[src].erase(data.dst) == 0) {
-          std::cerr << "ERROR: We found a duplicate but couldn't remove???" << std::endl;
-          exit(EXIT_FAILURE);
-        }
-        edges_delta--;
-      } else {
-        edges_delta++;
-      }
-    }
   }
-  num_edges += edges_delta;
 
   if (ret.size() == 0 && true_min_subgraph < cur_first_es_subgraph) {
     return vertex_advance_subgraph(cur_first_es_subgraph);
@@ -116,7 +112,7 @@ std::vector<Edge> EdgeStore::get_edges() {
 
   for (node_id_t src = 0; src < num_vertices; src++) {
     for (auto data : adjlist[src]) {
-      ret.push_back({src, data.first});
+      ret.push_back({src, data.dst});
     }
   }
 
@@ -130,8 +126,8 @@ void EdgeStore::verify_contract_complete() {
     if (adjlist[i].size() == 0) continue;
 
     auto it = adjlist[i].begin();
-    if (it->second < cur_subgraph) {
-      std::cerr << "ERROR: Found " << it->second << ", " << it->first  << " which should have been deleted by contraction to " << cur_subgraph << std::endl;
+    if (it->subgraph < cur_subgraph) {
+      std::cerr << "ERROR: Found " << it->subgraph << ", " << it->dst  << " which should have been deleted by contraction to " << cur_subgraph << std::endl;
       exit(EXIT_FAILURE);
     }
   }
@@ -147,26 +143,25 @@ std::vector<SubgraphTaggedUpdate> EdgeStore::vertex_contract(node_id_t src) {
     return ret;
 
   vertex_contracted[src] = true;
+  auto &data_buffer = adjlist[src];
+  size_t orig_size = data_buffer.size();
 
-  if (adjlist[src].size() == 0) {
+  if (data_buffer.size() == 0) {
     return ret;
   }
 
-  ret.reserve(adjlist[src].size());
-  int edges_delta = 0;
-  for (auto it = adjlist[src].begin(); it != adjlist[src].end();) {
-    ret.push_back({src, it->first});
-    if (it->second < cur_subgraph) {
-      edges_delta--;
-      it = adjlist[src].erase(it);
+  ret.resize(data_buffer.size());
+  size_t keep_idx = 0;
+  for (size_t i = 0; i < data_buffer.size(); i++) {
+    ret[i] = {src, data_buffer[i].dst};
+    if (data_buffer[i].subgraph >= cur_subgraph) {
+      data_buffer[keep_idx++] = data_buffer[i];
     }
-    else {
-      ++it;
-    }
-
   }
 
-  num_edges += edges_delta;
+  data_buffer.resize(keep_idx);
+
+  num_edges += data_buffer.size() - orig_size;
   return ret;
 }
 
@@ -200,7 +195,7 @@ TaggedUpdateBatch EdgeStore::vertex_advance_subgraph(node_id_t cur_first_es_subg
 
 // checks if we should perform a contraction and begins the process if so
 void EdgeStore::check_if_too_big() {
-  if (num_edges * store_edge_bytes < sketch_bytes) {
+  if (num_edges < max_edges) {
     // no contraction needed
     return;
   }
@@ -223,7 +218,5 @@ void EdgeStore::check_if_too_big() {
 
   std::cerr << "EdgeStore: Contracting to subgraphs " << cur_subgraph << " and above" << std::endl;
   std::cerr << "    num_edges = " << num_edges << std::endl;
-  std::cerr << "    store_edge_bytes = " << store_edge_bytes << std::endl; 
-  std::cerr << "    sketch_bytes = " << sketch_bytes << std::endl;
-
+  std::cerr << "    max_edges = " << max_edges << std::endl;
 }


### PR DESCRIPTION
We previously used sets to manage the edge store. This pull request switches to sorted buffers.

Should be about 3x faster and still correct... hopefully.